### PR TITLE
Update internal links to use the 'pages' directory for improved navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,7 +194,7 @@
                 <p>Learn more about each module and how they work together</p>
                 <div class="cta-buttons">
                     <a href="features.html" class="btn btn-primary">Explore Features</a>
-                    <a href="roadmap.html" class="btn btn-secondary">View Roadmap</a>
+                    <a href="pages/roadmap.html" class="btn btn-secondary">View Roadmap</a>
                 </div>
             </div>
         </div>
@@ -237,17 +237,17 @@
                 <div class="cta-item">
                     <h3>🚀 Start Building</h3>
                     <p>Get started with our tools and see how easy secure development can be</p>
-                    <a href="getting-started.html" class="btn btn-primary">Get Started</a>
+                    <a href="pages/getting-started.html" class="btn btn-primary">Get Started</a>
                 </div>
                 <div class="cta-item">
                     <h3>📚 Learn More</h3>
                     <p>Dive deeper into our story, principles, and approach to security</p>
-                    <a href="about.html" class="btn btn-primary">About Us</a>
+                    <a href="pages/about.html" class="btn btn-primary">About Us</a>
                 </div>
                 <div class="cta-item">
                     <h3>👥 Join Us</h3>
                     <p>Become part of the community building the future of security</p>
-                    <a href="community.html" class="btn btn-primary">Join Community</a>
+                    <a href="pages/community.html" class="btn btn-primary">Join Community</a>
                 </div>
             </div>
         </div>
@@ -266,17 +266,17 @@
                 <div class="link-group">
                     <h4>Project</h4>
                     <ul>
-                        <li><a href="about.html">About</a></li>
-                        <li><a href="roadmap.html">Roadmap</a></li>
-                        <li><a href="community.html">Community</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
+                        <li><a href="pages/about.html">About</a></li>
+                        <li><a href="pages/roadmap.html">Roadmap</a></li>
+                        <li><a href="pages/community.html">Community</a></li>
+                        <li><a href="pages/faq.html">FAQ</a></li>
                     </ul>
                 </div>
                 <div class="link-group">
                     <h4>Resources</h4>
                     <ul>
                         <li><a href="https://horizonsec.github.io/horizon-documentation" target="_blank">Documentation</a></li>
-                        <li><a href="getting-started.html">Getting Started</a></li>
+                        <li><a href="pages/getting-started.html">Getting Started</a></li>
                         <li><a href="https://github.com/HorizonSec" target="_blank">GitHub</a></li>
                         <li><a href="https://discord.gg/KkKxwxetZt" target="_blank">Discord</a></li>
                     </ul>

--- a/pages/about.html
+++ b/pages/about.html
@@ -24,12 +24,12 @@
                 </div>
                 <ul class="nav-menu">
                     <li><a href="../index.html">Home</a></li>
-                    <li><a href="about.html" class="active">About</a></li>
+                    <li><a href="pages/about.html" class="active">About</a></li>
                     <li><a href="features.html">Features</a></li>
-                    <li><a href="getting-started.html">Get Started</a></li>
-                    <li><a href="roadmap.html">Roadmap</a></li>
-                    <li><a href="community.html">Community</a></li>
-                    <li><a href="faq.html">FAQ</a></li>
+                    <li><a href="pages/getting-started.html">Get Started</a></li>
+                    <li><a href="pages/roadmap.html">Roadmap</a></li>
+                    <li><a href="pages/community.html">Community</a></li>
+                    <li><a href="pages/faq.html">FAQ</a></li>
                 </ul>
                 <div class="nav-toggle">☰</div>
             </div>
@@ -222,7 +222,7 @@
                     <h3>Built by Builders, for Builders</h3>
                     <p>The HorizonSec Project is led by four founders who understand the challenges builders face because we've lived them. But this isn't just our project—it's a community effort. Every line of code, every feature, and every decision is made with one goal: making security accessible and transparent for everyone who builds software.</p>
                     <div class="cta-buttons">
-                        <a href="community.html" class="btn btn-primary">Join Our Community</a>
+                        <a href="pages/community.html" class="btn btn-primary">Join Our Community</a>
                         <a href="https://github.com/HorizonSec" class="btn btn-secondary" target="_blank">View on GitHub</a>
                     </div>
                 </div>
@@ -242,17 +242,17 @@
                 <div class="link-group">
                     <h4>Project</h4>
                     <ul>
-                        <li><a href="about.html">About</a></li>
-                        <li><a href="roadmap.html">Roadmap</a></li>
-                        <li><a href="community.html">Community</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
+                        <li><a href="pages/about.html">About</a></li>
+                        <li><a href="pages/roadmap.html">Roadmap</a></li>
+                        <li><a href="pages/community.html">Community</a></li>
+                        <li><a href="pages/faq.html">FAQ</a></li>
                     </ul>
                 </div>
                 <div class="link-group">
                     <h4>Resources</h4>
                     <ul>
                         <li><a href="https://horizonsec.github.io/horizon-documentation" target="_blank">Documentation</a></li>
-                        <li><a href="getting-started.html">Getting Started</a></li>
+                        <li><a href="pages/getting-started.html">Getting Started</a></li>
                         <li><a href="https://github.com/HorizonSec" target="_blank">GitHub</a></li>
                         <li><a href="https://discord.gg/KkKxwxetZt" target="_blank">Discord</a></li>
                     </ul>

--- a/pages/community.html
+++ b/pages/community.html
@@ -24,12 +24,12 @@
                 </div>
                 <ul class="nav-menu">
                     <li><a href="../index.html">Home</a></li>
-                    <li><a href="about.html">About</a></li>
+                    <li><a href="pages/about.html">About</a></li>
                     <li><a href="features.html">Features</a></li>
-                    <li><a href="getting-started.html">Get Started</a></li>
-                    <li><a href="roadmap.html">Roadmap</a></li>
-                    <li><a href="community.html" class="active">Community</a></li>
-                    <li><a href="faq.html">FAQ</a></li>
+                    <li><a href="pages/getting-started.html">Get Started</a></li>
+                    <li><a href="pages/roadmap.html">Roadmap</a></li>
+                    <li><a href="pages/community.html" class="active">Community</a></li>
+                    <li><a href="pages/faq.html">FAQ</a></li>
                 </ul>
                 <div class="nav-toggle">☰</div>
             </div>
@@ -340,17 +340,17 @@
                 <div class="link-group">
                     <h4>Project</h4>
                     <ul>
-                        <li><a href="about.html">About</a></li>
-                        <li><a href="roadmap.html">Roadmap</a></li>
-                        <li><a href="community.html">Community</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
+                        <li><a href="pages/about.html">About</a></li>
+                        <li><a href="pages/roadmap.html">Roadmap</a></li>
+                        <li><a href="pages/community.html">Community</a></li>
+                        <li><a href="pages/faq.html">FAQ</a></li>
                     </ul>
                 </div>
                 <div class="link-group">
                     <h4>Resources</h4>
                     <ul>
                         <li><a href="https://horizonsec.github.io/horizon-documentation" target="_blank">Documentation</a></li>
-                        <li><a href="getting-started.html">Getting Started</a></li>
+                        <li><a href="pages/getting-started.html">Getting Started</a></li>
                         <li><a href="https://github.com/HorizonSec" target="_blank">GitHub</a></li>
                         <li><a href="https://discord.gg/KkKxwxetZt" target="_blank">Discord</a></li>
                     </ul>

--- a/pages/faq.html
+++ b/pages/faq.html
@@ -24,12 +24,12 @@
                 </div>
                 <ul class="nav-menu">
                     <li><a href="../index.html">Home</a></li>
-                    <li><a href="about.html">About</a></li>
+                    <li><a href="pages/about.html">About</a></li>
                     <li><a href="features.html">Features</a></li>
-                    <li><a href="getting-started.html">Get Started</a></li>
-                    <li><a href="roadmap.html">Roadmap</a></li>
-                    <li><a href="community.html">Community</a></li>
-                    <li><a href="faq.html" class="active">FAQ</a></li>
+                    <li><a href="pages/getting-started.html">Get Started</a></li>
+                    <li><a href="pages/roadmap.html">Roadmap</a></li>
+                    <li><a href="pages/community.html">Community</a></li>
+                    <li><a href="pages/faq.html" class="active">FAQ</a></li>
                 </ul>
                 <div class="nav-toggle">☰</div>
             </div>
@@ -140,7 +140,7 @@
 
                 <div class="faq-item">
                     <h3>Where can I see the project roadmap?</h3>
-                    <p>Our detailed roadmap is available on our <a href="roadmap.html">Roadmap page</a>. We also maintain public project boards on GitHub where you can track development progress in real-time. All planning discussions happen in our GitHub Discussions forum.</p>
+                    <p>Our detailed roadmap is available on our <a href="pages/roadmap.html">Roadmap page</a>. We also maintain public project boards on GitHub where you can track development progress in real-time. All planning discussions happen in our GitHub Discussions forum.</p>
                 </div>
             </div>
         </div>
@@ -164,7 +164,7 @@ docker run horizonsec/artemis scan .
 # Library/SDK
 pip install horizon-demeter</code></pre>
                     </div>
-                    <p>See our <a href="getting-started.html">Getting Started guide</a> for detailed instructions.</p>
+                    <p>See our <a href="pages/getting-started.html">Getting Started guide</a> for detailed instructions.</p>
                 </div>
 
                 <div class="faq-item">
@@ -279,7 +279,6 @@ pip install horizon-demeter</code></pre>
                     <ul>
                         <li><strong>Volunteer contributions:</strong> Time and expertise from community members</li>
                         <li><strong>Sponsorships:</strong> Organizations that benefit from and support the project</li>
-                        <li><strong>Grants:</strong> Open source and security-focused foundation grants</li>
                     </ul>
                     <p>All funding is transparent and used solely for project development and infrastructure.</p>
                 </div>
@@ -315,7 +314,7 @@ pip install horizon-demeter</code></pre>
                         <li><strong>Design:</strong> UI/UX, graphics, branding</li>
                         <li><strong>Community:</strong> Support, mentoring, advocacy</li>
                     </ul>
-                    <p>Visit our <a href="community.html">Community page</a> to get started.</p>
+                    <p>Visit our <a href="pages/community.html">Community page</a> to get started.</p>
                 </div>
 
                 <div class="faq-item">
@@ -414,7 +413,7 @@ pip install horizon-demeter</code></pre>
 
                 <div class="faq-item">
                     <h3>When will the tools be available?</h3>
-                    <p>See our <a href="roadmap.html">Roadmap</a> for detailed timelines and progress tracking.</p>
+                    <p>See our <a href="pages/roadmap.html">Roadmap</a> for detailed timelines and progress tracking.</p>
                 </div>
 
                 <div class="faq-item">
@@ -486,17 +485,17 @@ pip install horizon-demeter</code></pre>
                 <div class="link-group">
                     <h4>Project</h4>
                     <ul>
-                        <li><a href="about.html">About</a></li>
-                        <li><a href="roadmap.html">Roadmap</a></li>
-                        <li><a href="community.html">Community</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
+                        <li><a href="pages/about.html">About</a></li>
+                        <li><a href="pages/roadmap.html">Roadmap</a></li>
+                        <li><a href="pages/community.html">Community</a></li>
+                        <li><a href="pages/faq.html">FAQ</a></li>
                     </ul>
                 </div>
                 <div class="link-group">
                     <h4>Resources</h4>
                     <ul>
                         <li><a href="https://horizonsec.github.io/horizon-documentation" target="_blank">Documentation</a></li>
-                        <li><a href="getting-started.html">Getting Started</a></li>
+                        <li><a href="pages/getting-started.html">Getting Started</a></li>
                         <li><a href="https://github.com/HorizonSec" target="_blank">GitHub</a></li>
                         <li><a href="https://discord.gg/KkKxwxetZt" target="_blank">Discord</a></li>
                     </ul>

--- a/pages/features.html
+++ b/pages/features.html
@@ -24,12 +24,12 @@
                 </div>
                 <ul class="nav-menu">
                     <li><a href="../index.html">Home</a></li>
-                    <li><a href="about.html">About</a></li>
+                    <li><a href="pages/about.html">About</a></li>
                     <li><a href="features.html" class="active">Features</a></li>
-                    <li><a href="getting-started.html">Get Started</a></li>
-                    <li><a href="roadmap.html">Roadmap</a></li>
-                    <li><a href="community.html">Community</a></li>
-                    <li><a href="faq.html">FAQ</a></li>
+                    <li><a href="pages/getting-started.html">Get Started</a></li>
+                    <li><a href="pages/roadmap.html">Roadmap</a></li>
+                    <li><a href="pages/community.html">Community</a></li>
+                    <li><a href="pages/faq.html">FAQ</a></li>
                 </ul>
                 <div class="nav-toggle">☰</div>
             </div>
@@ -308,7 +308,7 @@
             <h2>Ready to Get Started?</h2>
             <p>Experience the power of transparent, actionable security tools designed for modern development workflows.</p>
             <div class="cta-buttons">
-                <a href="getting-started.html" class="btn btn-primary">Get Started Now</a>
+                <a href="pages/getting-started.html" class="btn btn-primary">Get Started Now</a>
                 <a href="https://github.com/HorizonSec" class="btn btn-secondary" target="_blank">Explore on GitHub</a>
             </div>
         </div>
@@ -326,17 +326,17 @@
                 <div class="link-group">
                     <h4>Project</h4>
                     <ul>
-                        <li><a href="about.html">About</a></li>
-                        <li><a href="roadmap.html">Roadmap</a></li>
-                        <li><a href="community.html">Community</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
+                        <li><a href="pages/about.html">About</a></li>
+                        <li><a href="pages/roadmap.html">Roadmap</a></li>
+                        <li><a href="pages/community.html">Community</a></li>
+                        <li><a href="pages/faq.html">FAQ</a></li>
                     </ul>
                 </div>
                 <div class="link-group">
                     <h4>Resources</h4>
                     <ul>
                         <li><a href="https://horizonsec.github.io/horizon-documentation" target="_blank">Documentation</a></li>
-                        <li><a href="getting-started.html">Getting Started</a></li>
+                        <li><a href="pages/getting-started.html">Getting Started</a></li>
                         <li><a href="https://github.com/HorizonSec" target="_blank">GitHub</a></li>
                         <li><a href="https://discord.gg/KkKxwxetZt" target="_blank">Discord</a></li>
                     </ul>

--- a/pages/getting-started.html
+++ b/pages/getting-started.html
@@ -24,12 +24,12 @@
                 </div>
                 <ul class="nav-menu">
                     <li><a href="../index.html">Home</a></li>
-                    <li><a href="about.html">About</a></li>
+                    <li><a href="pages/about.html">About</a></li>
                     <li><a href="features.html">Features</a></li>
-                    <li><a href="getting-started.html" class="active">Get Started</a></li>
-                    <li><a href="roadmap.html">Roadmap</a></li>
-                    <li><a href="community.html">Community</a></li>
-                    <li><a href="faq.html">FAQ</a></li>
+                    <li><a href="pages/getting-started.html" class="active">Get Started</a></li>
+                    <li><a href="pages/roadmap.html">Roadmap</a></li>
+                    <li><a href="pages/community.html">Community</a></li>
+                    <li><a href="pages/faq.html">FAQ</a></li>
                 </ul>
                 <div class="nav-toggle">☰</div>
             </div>
@@ -390,7 +390,7 @@ artemis report --webhook https://your-app.com/security</code></pre>
                         <div class="step-icon">💬</div>
                         <h3>Join the Community</h3>
                         <p>Connect with other builders, get support, and contribute to the project.</p>
-                        <a href="community.html" class="btn btn-secondary">Join Community</a>
+                        <a href="pages/community.html" class="btn btn-secondary">Join Community</a>
                     </div>
 
                     <div class="next-step-card">
@@ -404,7 +404,7 @@ artemis report --webhook https://your-app.com/security</code></pre>
                         <div class="step-icon">🗺️</div>
                         <h3>View the Roadmap</h3>
                         <p>See what's coming next and how you can help shape the future of HorizonSec.</p>
-                        <a href="roadmap.html" class="btn btn-secondary">View Roadmap</a>
+                        <a href="pages/roadmap.html" class="btn btn-secondary">View Roadmap</a>
                     </div>
                 </div>
             </div>
@@ -434,7 +434,7 @@ artemis report --webhook https://your-app.com/security</code></pre>
                 <div class="support-option">
                     <h3>❓ FAQ</h3>
                     <p>Common questions and answers</p>
-                    <a href="faq.html">View FAQ</a>
+                    <a href="pages/faq.html">View FAQ</a>
                 </div>
             </div>
         </div>
@@ -452,17 +452,17 @@ artemis report --webhook https://your-app.com/security</code></pre>
                 <div class="link-group">
                     <h4>Project</h4>
                     <ul>
-                        <li><a href="about.html">About</a></li>
-                        <li><a href="roadmap.html">Roadmap</a></li>
-                        <li><a href="community.html">Community</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
+                        <li><a href="pages/about.html">About</a></li>
+                        <li><a href="pages/roadmap.html">Roadmap</a></li>
+                        <li><a href="pages/community.html">Community</a></li>
+                        <li><a href="pages/faq.html">FAQ</a></li>
                     </ul>
                 </div>
                 <div class="link-group">
                     <h4>Resources</h4>
                     <ul>
                         <li><a href="https://horizonsec.github.io/horizon-documentation" target="_blank">Documentation</a></li>
-                        <li><a href="getting-started.html">Getting Started</a></li>
+                        <li><a href="pages/getting-started.html">Getting Started</a></li>
                         <li><a href="https://github.com/HorizonSec" target="_blank">GitHub</a></li>
                         <li><a href="https://discord.gg/KkKxwxetZt" target="_blank">Discord</a></li>
                     </ul>

--- a/pages/roadmap.html
+++ b/pages/roadmap.html
@@ -24,12 +24,12 @@
                 </div>
                 <ul class="nav-menu">
                     <li><a href="../index.html">Home</a></li>
-                    <li><a href="about.html">About</a></li>
+                    <li><a href="pages/about.html">About</a></li>
                     <li><a href="features.html">Features</a></li>
-                    <li><a href="getting-started.html">Get Started</a></li>
-                    <li><a href="roadmap.html" class="active">Roadmap</a></li>
-                    <li><a href="community.html">Community</a></li>
-                    <li><a href="faq.html">FAQ</a></li>
+                    <li><a href="pages/getting-started.html">Get Started</a></li>
+                    <li><a href="pages/roadmap.html" class="active">Roadmap</a></li>
+                    <li><a href="pages/community.html">Community</a></li>
+                    <li><a href="pages/faq.html">FAQ</a></li>
                 </ul>
                 <div class="nav-toggle">☰</div>
             </div>
@@ -356,17 +356,17 @@
                 <div class="link-group">
                     <h4>Project</h4>
                     <ul>
-                        <li><a href="about.html">About</a></li>
-                        <li><a href="roadmap.html">Roadmap</a></li>
-                        <li><a href="community.html">Community</a></li>
-                        <li><a href="faq.html">FAQ</a></li>
+                        <li><a href="pages/about.html">About</a></li>
+                        <li><a href="pages/roadmap.html">Roadmap</a></li>
+                        <li><a href="pages/community.html">Community</a></li>
+                        <li><a href="pages/faq.html">FAQ</a></li>
                     </ul>
                 </div>
                 <div class="link-group">
                     <h4>Resources</h4>
                     <ul>
                         <li><a href="https://horizonsec.github.io/horizon-documentation" target="_blank">Documentation</a></li>
-                        <li><a href="getting-started.html">Getting Started</a></li>
+                        <li><a href="pages/getting-started.html">Getting Started</a></li>
                         <li><a href="https://github.com/HorizonSec" target="_blank">GitHub</a></li>
                         <li><a href="https://discord.gg/KkKxwxetZt" target="_blank">Discord</a></li>
                     </ul>


### PR DESCRIPTION
This pull request standardizes internal navigation across the site by updating all links to project-related pages so that they consistently use the `pages/` subdirectory. This improves maintainability and prevents broken links as the site structure evolves.

Navigation and link consistency:

* Updated navigation menus in `index.html`, `pages/about.html`, `pages/community.html`, `pages/features.html`, `pages/getting-started.html`, and `pages/faq.html` so that links to "About", "Roadmap", "Community", "FAQ", and "Getting Started" now point to their respective files under the `pages/` directory. [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L197-R197) [[2]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L240-R250) [[3]](diffhunk://#diff-9ddfd3b5b96d22475bea3d6477e507613fd0ddd610444a2189f01543414357f1L27-R32) [[4]](diffhunk://#diff-ed5c7aaffacaefb138e494b537ed70f5ebb53dfcaeee61bc41fa66b556cad6beL27-R32) [[5]](diffhunk://#diff-ee5af5a9c88226b852633350f26993f33033864ad852394150400ebf87b52652L27-R32) [[6]](diffhunk://#diff-6dcf44c565dd735944e3abf703528daf4c9b74946a101245c5bc77e2ffbbbba8L27-R32) [[7]](diffhunk://#diff-f75aac8ebcbb9718e73bf3990061a0f98feb49a25c664338ea6a123afb299d24L27-R32)

Footer and sidebar link updates:

* Changed all footer and sidebar links to project pages (About, Roadmap, Community, FAQ, Getting Started) in every relevant file to use the `pages/` path for consistency. [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L269-R279) [[2]](diffhunk://#diff-9ddfd3b5b96d22475bea3d6477e507613fd0ddd610444a2189f01543414357f1L245-R255) [[3]](diffhunk://#diff-ed5c7aaffacaefb138e494b537ed70f5ebb53dfcaeee61bc41fa66b556cad6beL343-R353) [[4]](diffhunk://#diff-ee5af5a9c88226b852633350f26993f33033864ad852394150400ebf87b52652L489-R498) [[5]](diffhunk://#diff-6dcf44c565dd735944e3abf703528daf4c9b74946a101245c5bc77e2ffbbbba8L329-R339)

Content references:

* Updated references within page content (such as buttons and informational links) to use the new `pages/` path, ensuring users are directed to the correct location. [[1]](diffhunk://#diff-9ddfd3b5b96d22475bea3d6477e507613fd0ddd610444a2189f01543414357f1L225-R225) [[2]](diffhunk://#diff-6dcf44c565dd735944e3abf703528daf4c9b74946a101245c5bc77e2ffbbbba8L311-R311) [[3]](diffhunk://#diff-f75aac8ebcbb9718e73bf3990061a0f98feb49a25c664338ea6a123afb299d24L393-R393) [[4]](diffhunk://#diff-f75aac8ebcbb9718e73bf3990061a0f98feb49a25c664338ea6a123afb299d24L407-R407)

FAQ page corrections:

* Fixed all internal FAQ page links to point to the correct `pages/` subdirectory, including links to Roadmap, Getting Started, and Community pages. [[1]](diffhunk://#diff-ee5af5a9c88226b852633350f26993f33033864ad852394150400ebf87b52652L143-R143) [[2]](diffhunk://#diff-ee5af5a9c88226b852633350f26993f33033864ad852394150400ebf87b52652L167-R167) [[3]](diffhunk://#diff-ee5af5a9c88226b852633350f26993f33033864ad852394150400ebf87b52652L318-R317) [[4]](diffhunk://#diff-ee5af5a9c88226b852633350f26993f33033864ad852394150400ebf87b52652L417-R416)

Minor content adjustment:

* Removed the "Grants" funding source from the FAQ section on project funding.